### PR TITLE
Update to 2.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.0" %}
+{% set version = "2.2.1" %}
 
 package:
   name: libgdal
@@ -7,7 +7,7 @@ package:
 source:
   fn: gdal-{{ version }}.tar.gz
   url: http://download.osgeo.org/gdal/{{ version }}/gdal-{{ version }}.tar.gz
-  sha256: d06546a6e34b77566512a2559e9117402320dd9487de9aa95cb8a377815dc360
+  sha256: 61837706abfa3e493f3550236efc2c14bd6b24650232f9107db50a944abf8b2f
   # Workaround to allow CircleCI to complete.
   patches:
     # Fixes compilation problems with JPEG.


### PR DESCRIPTION
See https://trac.osgeo.org/gdal/wiki/Release/2.2.1-News