### PR TITLE
Add geotiff support

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -76,7 +76,9 @@ set BLD_OPTS=%WIN64% ^
     TIFF_OPTS=-DBIGTIFF_SUPPORT ^
     XERCES_DIR=%LIBRARY_PREFIX% ^
     XERCES_INCLUDE="-I%LIBRARY_INC% -I%LIBRARY_INC%\xercesc" ^
-    XERCES_LIB=%LIBRARY_LIB%\xerces-c_3.lib
+    XERCES_LIB=%LIBRARY_LIB%\xerces-c_3.lib ^
+    GEOTIFF_INC="-I%LIBRARY_INC%" ^
+    GEOTIFF_LIB=%LIBRARY_LIB%\geotiff_i.lib
 
 nmake /f makefile.vc %BLD_OPTS%
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -72,6 +72,7 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
             --with-libz=$PREFIX \
             --with-libkml=$PREFIX \
             --with-libtiff=$PREFIX \
+            --with-geotiff=$PREFIX \
             --with-liblzma=yes \
             --with-netcdf=$PREFIX \
             --with-openjpeg=$PREFIX \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,8 @@ requirements:
     - python  # [win]
     - cmake  # [win]
     - curl >=7.54.1,<8
-    - boost-cpp 1.65.1
+    # boost needed for KML
+    - boost-cpp 1.65.1  # [not win]
     - expat 2.1.*
     - freexl
     - geos 3.6.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - multiprocessor.patch
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win and py36]
   features:
     - vc9  # [win and py27]
@@ -28,6 +28,7 @@ requirements:
     - python  # [win]
     - cmake  # [win]
     - curl >=7.54.1,<8
+    - boost-cpp 1.65.1
     - expat 2.1.*
     - freexl
     - geos 3.6.2
@@ -50,6 +51,7 @@ requirements:
     - sqlite 3.13.*
     - xerces-c
     - zlib 1.2.11  # [not win]
+    - geotiff
     - xz 5.2.*
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
@@ -77,6 +79,7 @@ requirements:
     - sqlite 3.13.*
     - xerces-c
     - zlib 1.2.11  # [not win]
+    - geotiff
     - xz 5.2.*
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]


### PR DESCRIPTION
This PR adds external geotiff linking to GDAL (2.1.x branch).

I had to add `boost-cpp` as a build requirement as the KML stuff didn't compile otherwise - not sure if anyone knows why this used to work without it??

xref: https://github.com/conda-forge/gdal-feedstock/issues/187