### PR TITLE
Terrible workaround to make conda channel preference actually work

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,6 @@ environment:
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
 
-    - TARGET_ARCH: x64
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
     - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
@@ -43,24 +39,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -78,7 +78,9 @@ set BLD_OPTS=%WIN64% ^
     XERCES_INCLUDE="-I%LIBRARY_INC% -I%LIBRARY_INC%\xercesc" ^
     XERCES_LIB=%LIBRARY_LIB%\xerces-c_3.lib ^
     GEOTIFF_INC="-I%LIBRARY_INC%" ^
-    GEOTIFF_LIB=%LIBRARY_LIB%\geotiff_i.lib
+    GEOTIFF_LIB=%LIBRARY_LIB%\geotiff_i.lib ^
+    LIBICONV_INCLUDE="-I%LIBRARY_INC% -DICONV_CONST= " ^
+    LIBICONV_LIBRARY="%LIBRARY_LIB%\iconv.lib"
 
 nmake /f makefile.vc %BLD_OPTS%
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -75,6 +75,7 @@ export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
             --with-geotiff=$PREFIX \
             --with-liblzma=yes \
             --with-netcdf=$PREFIX \
+            --with-libiconv-prefix=$PREFIX \
             --with-openjpeg=$PREFIX \
             --with-poppler=$PREFIX \
             --with-pcre \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - multiprocessor.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and py36]
   features:
     - vc9  # [win and py27]
@@ -25,6 +25,7 @@ build:
 
 requirements:
   build:
+    - boost 1.65.1  # only need to get conda-forge's libkml instead of defaults
     - python  # [win]
     - cmake  # [win]
     - curl >=7.54.1,<8
@@ -55,6 +56,7 @@ requirements:
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
   run:
+    - boost 1.65.1  # only need to get conda-forge's libkml instead of defaults
     - curl >=7.54.1,<8
     - expat 2.2.*
     - freexl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
 
 requirements:
   build:
-    - boost 1.66.0  # only need to get conda-forge's libkml instead of defaults
+    - boost 1.66.0  # only need to get conda-forge's libkml instead of defaults
     - python  # [win]
     - cmake  # [win]
     - curl >=7.54.1,<8
@@ -56,7 +56,7 @@ requirements:
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
   run:
-    - boost 1.66.0  # only need to get conda-forge's libkml instead of defaults
+    - boost 1.66.0  # only need to get conda-forge's libkml instead of defaults
     - curl >=7.54.1,<8
     - expat 2.2.*
     - freexl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
 
 requirements:
   build:
-    - boost 1.65.1  # only need to get conda-forge's libkml instead of defaults
+    - boost 1.66.0  # only need to get conda-forge's libkml instead of defaults
     - python  # [win]
     - cmake  # [win]
     - curl >=7.54.1,<8
@@ -56,7 +56,7 @@ requirements:
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
   run:
-    - boost 1.65.1  # only need to get conda-forge's libkml instead of defaults
+    - boost 1.66.0  # only need to get conda-forge's libkml instead of defaults
     - curl >=7.54.1,<8
     - expat 2.2.*
     - freexl


### PR DESCRIPTION
Conda-forge's `libkml` already depends on boost but conda channel preference is unreliable and sometimes it pulls `libkml` from defaults that is linked to `libbost` causing breakages like:

```
libgdal.so: undefined symbol: _ZN6kmldom5ParseERKSsPSs
```

The bogus dependency on boost in `libgdal` is only to force conda to choose the adequate `libkml`. This solution sucks but it is the best we can do until we move to conda-build 3 or fix conda's channel preference.