### PR TITLE
pin json-c

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - multiprocessor.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and py36]
   features:
     - vc9  # [win and py27]
@@ -38,7 +38,7 @@ requirements:
     - hdf4
     - hdf5 1.10.1
     - jpeg 9*
-    - json-c  # [not win]
+    - json-c 0.12.1  # [not win]
     - kealib >=1.4.7,<1.5
     - libdap4 3.18.*  # [not win]
     - libkml 1.3.0  # [not win]
@@ -68,7 +68,7 @@ requirements:
     - hdf4
     - hdf5 1.10.1
     - jpeg 9*
-    - json-c  # [not win]
+    - json-c 0.12.1  # [not win]
     - kealib >=1.4.7,<1.5
     - libdap4 3.18.*  # [not win]
     - libkml 1.3.0  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,6 +89,8 @@ requirements:
     - vc 14  # [win and (py35 or py36)]
 
 test:
+  requires:
+    - libstdcxx-ng  # [linux]
   files:
     - test_data
   commands:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -11,7 +11,6 @@ gdalwarp -s_srs "+proj=latlong" -t_srs "$proj4" -of EHdr grid.asc grid.flt
 gdalinfo cropped.cub
 
 # From @akorosov. See https://github.com/conda-forge/gdal-feedstock/issues/83
-export CPL_ZIP_ENCODING=UTF-8
 gdalinfo /vsizip/stere.zip/stere.tif
 
 # Check shapefile read.


### PR DESCRIPTION
We just updated `json-c` so this pinning is to keep the "status quo" of the current packages. I'll add a proper pinning scheme and update `gdal` to `2.3.0` once I get back home.

@gillins I'll be travelling today and tomorrow, if this passes can you merge it? Looks like things already broken for users at the moment :-(

https://travis-ci.org/conda-forge/rasterio-feedstock/builds/379795699

https://circleci.com/gh/conda-forge/rasterio-feedstock