### PR TITLE
pin kealib to 1.4.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - multiprocessor.patch
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win and py36]
   features:
     - vc9  # [win and py27]
@@ -39,7 +39,7 @@ requirements:
     - hdf5 1.10.1
     - jpeg 9*
     - json-c 0.12.1  # [not win]
-    - kealib >=1.4.7,<1.5
+    - kealib 1.4.7
     - libdap4 3.18.*  # [not win]
     - libkml 1.3.0  # [not win]
     - libnetcdf 4.4.*  # [win and py2k]
@@ -69,7 +69,7 @@ requirements:
     - hdf5 1.10.1
     - jpeg 9*
     - json-c 0.12.1  # [not win]
-    - kealib >=1.4.7,<1.5
+    - kealib 1.4.7
     - libdap4 3.18.*  # [not win]
     - libkml 1.3.0  # [not win]
     - libnetcdf 4.4.*  # [win and py2k]


### PR DESCRIPTION
Not a real solution, just a workaround for https://github.com/conda-forge/gdal-feedstock/issues/209 b/c `libnetcdf` is not compiling on Windows with `hdf5 1.10.2`.